### PR TITLE
fixes bug causing constant attributes becoming NaN

### DIFF
--- a/lof.py
+++ b/lof.py
@@ -82,7 +82,7 @@ class LOF:
         self.instances = new_instances
         
     def normalize_instance(self, instance):
-        return tuple(map(lambda value,max,min: (value-min)/(max-min), 
+        return tuple(map(lambda value,max,min: (value-min)/(max-min) if max-min > 0 else 0, 
                          instance, self.max_attribute_values, self.min_attribute_values))
         
     def local_outlier_factor(self, min_pts, instance):


### PR DESCRIPTION
If specific attribute is constant, normalization fails due to zero division. In general, such attributes should be removed, but during quick scripting they cause calculation to fail.
